### PR TITLE
feat: add pod, service, scheduling, and security configuration options

### DIFF
--- a/opal/templates/mongo-service.yaml
+++ b/opal/templates/mongo-service.yaml
@@ -5,7 +5,12 @@ metadata:
   name: mongo
   labels:
     {{- include "mongo.labels" . | nindent 4 }}
+  {{- with .Values.mongo.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  type: {{ .Values.mongo.service.type | default "ClusterIP" }}
   ports:
     - port: 27017
   selector:

--- a/opal/templates/mongo-statefulset.yaml
+++ b/opal/templates/mongo-statefulset.yaml
@@ -15,10 +15,37 @@ spec:
     metadata:
       labels:
         {{- include "mongo.selectorLabels" . | nindent 8 }}
+      {{- with .Values.mongo.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with .Values.mongo.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mongo.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.mongo.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mongo.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mongo.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: mongo
           image: {{ .Values.mongo.image }}
+          {{- with .Values.mongo.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.mongo.port | default "27017" }}
           env:

--- a/opal/templates/opal-service.yaml
+++ b/opal/templates/opal-service.yaml
@@ -4,7 +4,12 @@ metadata:
   name: {{ include "opal.name" . }}
   labels:
     {{ include "opal.labels" . | nindent 4 }}
+  {{- with .Values.opal.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  type: {{ .Values.opal.service.type | default "ClusterIP" }}
   ports:
     - port: 80
       targetPort: 8080

--- a/opal/templates/opal-statefulset.yaml
+++ b/opal/templates/opal-statefulset.yaml
@@ -14,12 +14,39 @@ spec:
     metadata:
       labels:
         {{- include "opal.selectorLabels" . | nindent 8 }}
+      {{- with .Values.opal.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.opal.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.opal.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.opal.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.opal.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.opal.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: opal
           image: {{ .Values.opal.image }}
           imagePullPolicy: {{ .Values.opal.imagePullPolicy }}
+          {{- with .Values.opal.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
           env:

--- a/opal/templates/postgres-data-service.yaml
+++ b/opal/templates/postgres-data-service.yaml
@@ -5,7 +5,12 @@ metadata:
   name: {{ .Values.postgres.data.name }}
   labels:
     {{- include "postgres.data.labels" . | nindent 4 }}
+  {{- with .Values.postgres.data.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  type: {{ .Values.postgres.data.service.type | default "ClusterIP" }}
   ports:
     - port: 5432
   selector:

--- a/opal/templates/postgres-data-statefulset.yaml
+++ b/opal/templates/postgres-data-statefulset.yaml
@@ -15,10 +15,37 @@ spec:
     metadata:
       labels:
         {{- include "postgres.data.selectorLabels" . | nindent 8 }}
+      {{- with .Values.postgres.data.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with .Values.postgres.data.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.data.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.postgres.data.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.data.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.data.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgres
           image: {{ .Values.postgres.data.image }}
+          {{- with .Values.postgres.data.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.postgres.data.port | default "5432" }}
           env:

--- a/opal/templates/postgres-ids-service.yaml
+++ b/opal/templates/postgres-ids-service.yaml
@@ -4,8 +4,13 @@ kind: Service
 metadata:
   name: {{ .Values.postgres.ids.name }}
   labels:
-    app: {{ .Values.postgres.ids.name }}
+    {{- include "postgres.ids.labels" . | nindent 4 }}
+  {{- with .Values.postgres.ids.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  type: {{ .Values.postgres.ids.service.type | default "ClusterIP" }}
   ports:
     - port: 5432
   selector:

--- a/opal/templates/postgres-ids-statefulset.yaml
+++ b/opal/templates/postgres-ids-statefulset.yaml
@@ -15,10 +15,37 @@ spec:
     metadata:
       labels:
         {{- include "postgres.ids.selectorLabels" . | nindent 8 }}
+      {{- with .Values.postgres.ids.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with .Values.postgres.ids.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.ids.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.postgres.ids.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.ids.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.ids.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgres
           image: {{ .Values.postgres.ids.image }}
+          {{- with .Values.postgres.ids.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.postgres.ids.port | default "5432" }}
           env:

--- a/opal/values.yaml
+++ b/opal/values.yaml
@@ -22,6 +22,8 @@ mongo:
   enabled: true
   name: mongo
   image: mongo:8.0
+  # Pod annotations for MongoDB
+  podAnnotations: {}
   pvcSize: 1Gi
   # Enable backup cronjob of internal or external MongoDB database
   backup:
@@ -39,11 +41,26 @@ mongo:
   password: example
   existingSecret: ""  # Override global.existingSecret if needed
   existingSecretKeys:
-    database: 
+    database:
       data: MONGO_DATABASE
       ids: MONGO_IDS
     user: MONGO_USER
     password: MONGO_PASSWORD
+  # Service configuration
+  service:
+    type: ClusterIP
+    annotations: {}
+  # Security context
+  podSecurityContext: {}
+  securityContext: {}
+  # Priority class name for scheduling
+  priorityClassName: ""
+  # Node selector for assignment
+  nodeSelector: {}
+  # Affinity rules for scheduling
+  affinity: {}
+  # Tolerations for scheduling
+  tolerations: []
 
 # PostgreSQL setup: apply PostgreSQL configuration to Opal
 usePostgres:
@@ -57,6 +74,8 @@ postgres:
     enabled: false
     name: postgres-data
     image: postgres:17-alpine
+    # Pod annotations for PostgreSQL
+    podAnnotations: {}
     pvcSize: 1Gi
     # Enable backup cronjob of internal or external PostgreSQL database
     backup:
@@ -75,11 +94,28 @@ postgres:
       database: POSTGRESDATA_DATABASE
       user: POSTGRESDATA_USER
       password: POSTGRESDATA_PASSWORD
+    # Service configuration
+    service:
+      type: ClusterIP
+      annotations: {}
+    # Security context
+    podSecurityContext: {}
+    securityContext: {}
+    # Priority class name for scheduling
+    priorityClassName: ""
+    # Node selector for assignment
+    nodeSelector: {}
+    # Affinity rules for  scheduling
+    affinity: {}
+    # Tolerations for scheduling
+    tolerations: []
   ids:
     # Enable internally managed PostgreSQL for IDs
     enabled: false
     name: postgres-ids
     image: postgres:17-alpine
+    # Pod annotations for PostgreSQL
+    podAnnotations: {}
     pvcSize: 1Gi
     # Enable backup cronjob of internal or external PostgreSQL database
     backup:
@@ -98,13 +134,30 @@ postgres:
       database: POSTGRESIDS_DATABASE
       user: POSTGRESIDS_USER
       password: POSTGRESIDS_PASSWORD
+    # Service configuration
+    service:
+      type: ClusterIP
+      annotations: {}
+    # Security context
+    podSecurityContext: {}
+    securityContext: {}
+    # Priority class name for scheduling
+    priorityClassName: ""
+    # Node selector for assignment
+    nodeSelector: {}
+    # Affinity rules for  scheduling
+    affinity: {}
+    # Tolerations for scheduling
+    tolerations: []
 
 # Opal configuration
 opal:
   # Container image configuration
   image: obiba/opal:5.3
   imagePullPolicy: Always
-  # Opal PVC size for persistent storage of configuration files and runtime work directory 
+  # Pod annotations for Opal
+  podAnnotations: {}
+  # Opal PVC size for persistent storage of configuration files and runtime work directory
   pvcSize: 1Gi
   # Java options
   javaOpts: "-Xms1G -Xmx2G -XX:+UseG1GC"
@@ -120,7 +173,7 @@ opal:
     existingSecret: ""  # Override global.existingSecret if needed
     secretKey: OPAL_ADMINISTRATOR_PASSWORD
   resources:
-    # Requested resources at pod start  
+    # Requested resources at pod start
     requests:
       memory: 1Gi
       cpu: "1"
@@ -128,6 +181,23 @@ opal:
     limits:
       memory: 2Gi
       cpu: "2"
+  # Service configuration
+  service:
+    # Service type (ClusterIP, NodePort, LoadBalancer)
+    type: ClusterIP
+    # Service annotations
+    annotations: {}
+  # Security context
+  podSecurityContext: {}
+  securityContext: {}
+  # Priority class name for pod scheduling
+  priorityClassName: ""
+  # Node selector for pod assignment
+  nodeSelector: {}
+  # Affinity rules for  scheduling
+  affinity: {}
+  # Tolerations for scheduling
+  tolerations: []
   rock:
     # Comma separated list of allowed Rock images
     imagesAllowed: ""

--- a/opal/values.yaml
+++ b/opal/values.yaml
@@ -105,7 +105,7 @@ postgres:
     priorityClassName: ""
     # Node selector for assignment
     nodeSelector: {}
-    # Affinity rules for  scheduling
+    # Affinity rules for scheduling
     affinity: {}
     # Tolerations for scheduling
     tolerations: []
@@ -145,7 +145,7 @@ postgres:
     priorityClassName: ""
     # Node selector for assignment
     nodeSelector: {}
-    # Affinity rules for  scheduling
+    # Affinity rules for scheduling
     affinity: {}
     # Tolerations for scheduling
     tolerations: []
@@ -194,7 +194,7 @@ opal:
   priorityClassName: ""
   # Node selector for pod assignment
   nodeSelector: {}
-  # Affinity rules for  scheduling
+  # Affinity rules for scheduling
   affinity: {}
   # Tolerations for scheduling
   tolerations: []


### PR DESCRIPTION
This update creates support for configuration fields across the opal, mongodb, and postgresql templates. The changes are;
- Pod annotations
- Pod level security context settings
- Container level security context settings
- Priority class settings
- Node selector, affinity rules, and tolerations
- Service annotations and service type configuration

All these template changes have been updated to read these values from values.yaml, and the values now includes defaults for each component. The changes are backward compatible as the new fields use empty defaults and fall back to existing behaviour when not set.